### PR TITLE
Fix reviews comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,4 +71,4 @@ node_modules
 promort/static/js/promort.min.js
 
 # Jupyter notebooks folder
-notebooks/
+notebooks

--- a/promort/reviews_manager/management/commands/check_gs_reviews.py
+++ b/promort/reviews_manager/management/commands/check_gs_reviews.py
@@ -1,0 +1,59 @@
+from django.core.management.base import BaseCommand
+from reviews_manager.models import ReviewsComparison
+
+import logging
+
+logger = logging.getLogger('promort_commands')
+
+
+class Command(BaseCommand):
+    help = 'check third reviewer\'s worklist and fix it if necessary'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--keep_reviews', action='store_true',
+                            help='Keep reviews performed by third reviewer even if not necessary')
+
+    def _get_review_comparisons(self):
+        return ReviewsComparison.objects.filter(positive_match=False, positive_quality_control=True)
+
+    def _delete_review(self, clinical_annotation):
+        if len(clinical_annotation.steps.all()) == 0:
+            clinical_annotation.delete()
+            logger.info('Clinical annotation %s deleted', clinical_annotation.label)
+
+    def _delete_gs_review_step(self, clinical_annotation_step):
+        fr_ann = clinical_annotation_step.focus_region_annotations.all()
+        logger.info('Deleting %d focus region annotations', len(fr_ann))
+        fr_ann.delete()
+        c_ann = clinical_annotation_step.core_annotations.all()
+        logger.info('Deleting %d core annotations', len(c_ann))
+        c_ann.delete()
+        s_ann = clinical_annotation_step.slice_annotations.all()
+        logger.info('Deleting %d slice annotations', len(s_ann))
+        s_ann.delete()
+        c_ann = clinical_annotation_step.clinical_annotation
+        clinical_annotation_step.delete()
+        logger.info('Clinical annotation step %s deleted', clinical_annotation_step.label)
+        self._delete_review(c_ann)
+
+    def _check_and_fix(self, rc_object, keep_review):
+        if not rc_object.review_1.rois_review_step.is_positive():
+            logger.info('### ReviewComparison object %d --- NEED TO FIX! ###', rc_object.id)
+            if rc_object.review_3 is not None and not keep_review:
+                r3_obj = rc_object.review_3
+                logger.info('-- Clearing reviews step %s --', r3_obj.label)
+                # unlink to prevent delete protection error
+                rc_object.review_3 = None
+                rc_object.save()
+                # delete clinical annotation step
+                self._delete_gs_review_step(r3_obj)
+            rc_object.positive_match = True
+            logger.info('Setting RC object positive_match to True')
+            rc_object.save()
+
+    def handle(self, *args, **opts):
+        logger.info('Collecting ReviewsComparison objects')
+        r_comp = self._get_review_comparisons()
+        logger.info('Retrieved %d objects', len(r_comp))
+        for rc in r_comp:
+            self._check_and_fix(rc, opts['keep_reviews'])

--- a/promort/reviews_manager/management/commands/compare_reviews.py
+++ b/promort/reviews_manager/management/commands/compare_reviews.py
@@ -22,6 +22,9 @@ class Command(BaseCommand):
     def _check_reviews_rejection(self, review1, review2):
         return review1.rejected or review2.rejected
 
+    def _is_positive_slide(self, rois_annotation_step):
+        return rois_annotation_step.is_positive()
+
     def _compare_slice_annotations(self, sl_ann_1, sl_ann_2):
         return True
 
@@ -91,19 +94,16 @@ class Command(BaseCommand):
         if not qc_passed:
             logger.info('Bad quality for review 1, stopping comparison')
             return False, qc_passed
+        # check if there is tumor presence on the slide
+        if not self._is_positive_slide(review_1.rois_review_step):
+            logger.info('Negative slide, no need for 3rd review')
+            return True, qc_passed
         # check if at least one of the two reviews was rejected
         rejected = self._check_reviews_rejection(review_1, review_2)
         if rejected:
             logger.info('Al least one review was rejected, stopping comparison')
             return False, qc_passed
         else:
-            # good_match = self._check_slices(review_1, review_2)
-            # if good_match:
-            #     good_match = self._check_cores(review_1, review_2)
-            #     if good_match:
-            #         good_match = self._check_focus_regions(review_1, review_2)
-            #         if good_match:
-            #             return True, qc_passed
             good_match = self._check_cores(review_1, review_2)
             if good_match:
                 return True, qc_passed

--- a/promort/reviews_manager/models.py
+++ b/promort/reviews_manager/models.py
@@ -91,6 +91,12 @@ class ROIsAnnotationStep(models.Model):
         else:
             raise IntegrityError('ROIs annotation step can\'t be reopened')
 
+    def is_positive(self):
+        for slice in self.slices.all():
+            if slice.is_positive():
+                return True
+        return False
+
 
 class ClinicalAnnotation(models.Model):
     reviewer = models.ForeignKey(User, on_delete=models.PROTECT,

--- a/promort/rois_manager/models.py
+++ b/promort/rois_manager/models.py
@@ -17,6 +17,12 @@ class Slice(models.Model):
     class Meta:
         unique_together = ('label', 'annotation_step')
 
+    def is_positive(self):
+        for core in self.cores.all():
+            if core.is_positive():
+                return True
+        return False
+
     def get_positive_cores_count(self):
         positive_cores_counter = 0
         for core in self.cores.all():


### PR DESCRIPTION
Reviews comparison tool wrongly assigned a slide review to the third reviewer if at least one of the first two reviewers discharged a slide even if it is a "negative" (no tumor presence) one.
Fixed the tool and added a new one to correct the database.