### PR TITLE
Update worklist creation tools

### DIFF
--- a/promort/reviews_manager/management/commands/build_rois_reviews_worklist.py
+++ b/promort/reviews_manager/management/commands/build_rois_reviews_worklist.py
@@ -24,6 +24,7 @@ from promort.settings import DEFAULT_GROUPS
 from slides_manager.models import Case
 from reviews_manager.models import ROIsAnnotation, ROIsAnnotationStep
 
+from csv import DictReader
 from uuid import uuid4
 import logging
 
@@ -31,27 +32,46 @@ logger = logging.getLogger('promort_commands')
 
 
 class Command(BaseCommand):
-    help = 'build first reviewers worklist based on the existing cases and slides'
+    help = 'build ROIs reviews worklist based on the existing cases and slides'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--worklist-file', dest='worklist', type=str, default=None,
+                            help='a CSV file containing the worklist, if not present reviews will be assigned randomly')
+        parser.add_argument('--allow-duplicated', action='store_true', dest='allow_duplicated',
+                            help='create worklist even for cases and slides that already have a related review')
 
     def _get_rois_manager_users(self):
         rois_manager_group = Group.objects.get(name=DEFAULT_GROUPS['rois_manager']['name'])
         return rois_manager_group.user_set.all()
 
+    def _get_rois_manager_map(self):
+        rois_managers = self._get_rois_manager_users()
+        return dict((u.username, u) for u in rois_managers)
+
     def _get_cases_list(self):
         return Case.objects.all()
 
+    def _get_cases_map(self):
+        cases = self._get_cases_list()
+        return dict((c.id, c) for c in cases)
+
     def _create_rois_annotation(self, case_obj, reviewer_obj):
-        try:
-            annotation_obj = ROIsAnnotation.objects.get(case=case_obj)
-            logger.info('There is already a ROIs Annotation object (label %s) and it\'s assigned to %s',
-                        annotation_obj.label, annotation_obj.reviewer.username)
-        except ROIsAnnotation.DoesNotExist:
-            annotation_obj = ROIsAnnotation(case=case_obj, reviewer=reviewer_obj,
-                                            label=uuid4().hex)
-            annotation_obj.save()
-            logger.info('Saved new ROIs Annotation with label %s and assigne to %s',
-                        annotation_obj.label, reviewer_obj.username)
+        annotation_obj = ROIsAnnotation(case=case_obj, reviewer=reviewer_obj,
+                                        label=uuid4().hex)
+        annotation_obj.save()
+        logger.info('Saved new ROIs Annotation with label %s and assigned to %s',
+                    annotation_obj.label, reviewer_obj.username)
         return annotation_obj
+
+    def _get_or_create_rois_annotation(self, case_obj, reviewer_obj):
+        annotation_objs = ROIsAnnotation.objects.filter(case=case_obj, reviewer=reviewer_obj)
+        if len(annotation_objs) > 0:
+            logger.info('There are already %d ROIs Annotations for case %s assigned to user %s',
+                        len(annotation_objs), case_obj.id, reviewer_obj.username)
+            return annotation_objs
+        else:
+            logger.info('No ROIs Annotation found, creating a new one')
+            return [self._create_rois_annotation(case_obj, reviewer_obj)]
 
     def _get_annotation_step_label(self, annotation_label, slide_label):
         slide_index = slide_label.split('-')[-1]
@@ -70,14 +90,47 @@ class Command(BaseCommand):
             logger.info('There is already a ROIs Annotation Step object (label %s)', annotation_step_obj.label)
         return annotation_step_obj
 
-    def handle(self, *args, **opts):
-        logger.info('=== Starting ROIs worklist creation ===')
+    def _create_case_annotation(self, case, reviewer, allow_duplicated):
+        if allow_duplicated:
+            annotation_objs = [self._create_rois_annotation(case, reviewer)]
+        else:
+            annotation_objs = self._get_or_create_rois_annotation(case, reviewer)
+        for slide in case.slides.all():
+            logger.info('Processing slide %s', slide.id)
+            for annotation_obj in annotation_objs:
+                logger.info('Creating steps for ROIs Annotation %s', annotation_obj.label)
+                self._create_rois_annotation_step(annotation_obj, slide)
+
+    def create_random_worklist(self, allow_duplicated):
+        logger.info('Creating RANDOM worklist')
         rois_managers = self._get_rois_manager_users()
         cases = self._get_cases_list()
         for i, case in enumerate(cases):
             logger.info('Processing case %s', case.id)
-            annotation_obj = self._create_rois_annotation(case, rois_managers[i % len(rois_managers)])
-            for slide in case.slides.all():
-                logger.info('Processing slide %s', slide.id)
-                self._create_rois_annotation_step(annotation_obj, slide)
+            self._create_case_annotation(case, rois_managers[i % len(rois_managers)], allow_duplicated)
+
+    def create_worklist_from_file(self, worklist_file, allow_duplicated):
+        with open(worklist_file) as f:
+            reader = DictReader(f)
+            cases_map = self._get_cases_map()
+            reviewers_map = self._get_rois_manager_map()
+            for row in reader:
+                logger.info('Processing case %s and assigning to reviewers %s', row['case_id'], row['reviewer'])
+                if row['case_id'] not in cases_map:
+                    logger.error('Case with ID %s is not on the system', row['case_id'])
+                    continue
+                if row['reviewer'] not in reviewers_map:
+                    logger.error('There is no reviewer with username %s', row['reviewer'])
+                    continue
+                self._create_case_annotation(cases_map[row['case_id']], reviewers_map[row['reviewer']],
+                                             allow_duplicated)
+
+    def handle(self, *args, **opts):
+        logger.info('=== Starting ROIs worklist creation ===')
+        worklist_file = opts['worklist']
+        allow_duplicated = opts['allow_duplicated']
+        if worklist_file:
+            self.create_worklist_from_file(worklist_file, allow_duplicated)
+        else:
+            self.create_random_worklist(allow_duplicated)
         logger.info('=== ROIs worklist creation completed ===')

--- a/promort/reviews_manager/management/commands/completed_reviews_slides_list.py
+++ b/promort/reviews_manager/management/commands/completed_reviews_slides_list.py
@@ -19,7 +19,7 @@
 
 from django.core.management.base import BaseCommand
 
-from reviews_manager.models import ReviewsComparison
+from reviews_manager.models import ClinicalAnnotation, ReviewsComparison
 
 import logging
 
@@ -32,10 +32,45 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--output_file', dest='out_file', type=str, required=True,
                             help='the output file for the slides list')
+        parser.add_argument('--by_reviews_comparison', dest='by_reviews_comparison', action='store_true',
+                            help='use ReviewsComparison objects to decide if the review for a slide is completed, otherwise simply use ClinicalAnnotation')
         parser.add_argument('--linked_only', action='store_true',
                             help='write in the output file only slides linked to images on the OMERO server')
 
-    def _get_slide(self, reviews_comparison, ome_link_active):
+    def _get_slides_by_clinical_annotations(self, ome_link_active):
+        completed_slides_list = set()
+        clinical_annotations = ClinicalAnnotation.objects.all()
+        logger.info('Loaded %d ClinicalAnnotation objects', len(clinical_annotations))
+        for ca in clinical_annotations:
+            if ca.is_completed():
+                slides = self._get_clinical_annotation_slides(ca, ome_link_active)
+                completed_slides_list = completed_slides_list.union(slides)
+        logger.info('Found %s slides related to completed reviews', len(completed_slides_list))
+        return completed_slides_list
+
+    def _get_clinical_annotation_slides(self, clinical_annotation, ome_link_active):
+        slides = set()
+        for step in clinical_annotation.steps.all():
+            if ome_link_active:
+                if step.slide.omero_id is not None:
+                    slides.add(step.slide.id)
+            else:
+                slides.add(step.slide.id)
+        return slides
+
+    def _get_slides_by_review_comparisons(self, ome_link_active):
+        completed_slides_list = set()
+        review_comparisons = ReviewsComparison.objects.all()
+        logger.info('Loaded %d ReviewsComparison objects', len(review_comparisons))
+        for rc in review_comparisons:
+            if rc.is_completed() and not rc.is_evaluation_pending():
+                s = self._get_slide_by_reviews_comparison(rc, ome_link_active)
+                if s is not None:
+                    completed_slides_list.add(s)
+        logger.info('Found %s slides related to completed reviews', len(completed_slides_list))
+        return completed_slides_list
+
+    def _get_slide_by_reviews_comparison(self, reviews_comparison, ome_link_active):
         # check if all related ClinicalAnnotation objects were closed
         if not reviews_comparison.linked_reviews_completed():
             return None
@@ -50,20 +85,17 @@ class Command(BaseCommand):
         else:
             return slide.id
 
+    def _write_output_file(self, completed_slides_list, output_file):
+        logger.info('Writing output file')
+        with open(output_file, 'w') as ofile:
+            for slide in completed_slides_list:
+                ofile.write('%s\n' % slide)
+
     def handle(self, *args, **opts):
         logger.info('=== Exporting list of slides with a complete review workflow ===')
-        completed_slides_list = []
-        review_comparions = ReviewsComparison.objects.all()
-        logger.info('Loaded %d ReviewsComparison objects', len(review_comparions))
-        for rc in review_comparions:
-            if rc.is_completed() and not rc.is_evaluation_pending():
-                s = self._get_slide(rc, opts['linked_only'])
-                if s is not None:
-                    completed_slides_list.append(s)
-        logger.info('%d slides related to completed review workflows', len(completed_slides_list))
-        if len(completed_slides_list) > 0:
-            logger.info('Writing output file')
-            with open(opts['out_file'], 'w') as ofile:
-                for slide in completed_slides_list:
-                    ofile.write('%s\n' % slide)
-        logger.info('=== Export complete ===')
+        if opts['by_reviews_comparison']:
+            completed_slides_list = self._get_slides_by_review_comparisons(opts['linked_only'])
+        else:
+            completed_slides_list = self._get_slides_by_clinical_annotations(opts['linked_only'])
+        self._write_output_file(completed_slides_list, opts['out_file'])
+        logger.info('=== Job completed ===')


### PR DESCRIPTION
ROIs annotation worklist craetion tool now accepts a CSV file as input and allows to create multiple review orders for the same slide and the same user.
Clinical annotation worklist creation tool now can create ore or more clinical annotations for each ROIs review depending on an optional parameter.