### PR TITLE
Add prediction map to ROIs annotation step

### DIFF
--- a/promort/predictions_manager/views.py
+++ b/promort/predictions_manager/views.py
@@ -66,8 +66,11 @@ class PredictionDetailBySlide(APIView):
         fetch_latest = strtobool(request.GET.get('latest', 'false'))
         prediction_type = request.GET.get('type')
         predictions = self._find_predictions_by_slide_id(pk, prediction_type, fetch_latest)
-        serializer = self.model_serializer(predictions, many = not fetch_latest)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        if (fetch_latest and predictions is None) or (not fetch_latest and len(predictions) == 0):
+            raise NotFound(f'No predictions found for the required query')
+        else:
+            serializer = self.model_serializer(predictions, many = not fetch_latest)
+            return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class PredictionRequireReview(APIView):

--- a/promort/promort/urls.py
+++ b/promort/promort/urls.py
@@ -100,6 +100,7 @@ urlpatterns = [
     path('api/cases/<slug:pk>/', CaseDetail.as_view()),
     path('api/slides/', SlideList.as_view()),
     path('api/slides/<slug:pk>/', SlideDetail.as_view()),
+    path('api/slides/<slug:pk>/predictions/', pmv.PredictionDetailBySlide.as_view()),
     path('api/slides_set/', SlidesSetList.as_view()),
     path('api/slides_set/<slug:pk>/', SlidesSetDetail.as_view()),
 

--- a/promort/src/js/ome_seadragon_viewer/viewer.controllers.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.controllers.js
@@ -255,13 +255,13 @@
                                          CurrentSlideDetailsService, CurrentAnnotationStepsDetailsService,
                                          HeatmapViewerService, CurrentPredictionDetailsService) {
         var vm = this;
+        vm.ome_base_url = undefined;
         vm.slide_id = undefined;
         vm.prediction_id = undefined;
         vm.annotation_step_label = undefined;
         vm.slide_details = undefined;
         vm.prediction_details = undefined;
         vm.dzi_url = undefined;
-        vm.dataset_dzi_url = undefined;
         vm.static_files_url = undefined;
         vm.loading_tiled_images = undefined;
         vm.current_opacity = undefined;
@@ -314,7 +314,7 @@
                 .then(OMEBaseURLSuccessFn, OMEBaseURLErrorFn);
 
             function OMEBaseURLSuccessFn(response) {
-                var base_url = response.data.base_url;
+                vm.ome_base_url = response.data.base_url;
                 vm.static_files_url = response.data.static_files_url + '/ome_seadragon/img/openseadragon/';
 
                 ViewerService.getSlideInfo(vm.slide_id)
@@ -323,9 +323,9 @@
                 function SlideInfoSuccessFn(response) {
                     vm.slide_details = response.data;
                     if (vm.slide_details.image_type === 'MIRAX') {
-                        vm.dzi_url = base_url + 'mirax/deepzoom/get/' + vm.slide_details.id + '.dzi';
+                        vm.dzi_url = vm.ome_base_url + 'mirax/deepzoom/get/' + vm.slide_details.id + '.dzi';
                     } else {
-                        vm.dzi_url = base_url + 'deepzoom/get/' + vm.slide_details.omero_id + '.dzi';
+                        vm.dzi_url = vm.ome_base_url + 'deepzoom/get/' + vm.slide_details.omero_id + '.dzi';
                     }
                     
                     if (typeof(vm.prediction_id) !== 'undefined') {
@@ -334,7 +334,6 @@
 
                         function PredictionInfoSuccessFn(response) {
                             vm.prediction_details = response.data;
-                            vm.dataset_dzi_url = base_url + 'arrays/deepzoom/get/' + vm.prediction_details.omero_id + '.dzi';
 
                             $rootScope.$broadcast('viewer.controller_initialized');
                         }
@@ -443,7 +442,7 @@
         }
 
         function getDatasetDZIURL(color_palette) {
-            return vm.dataset_dzi_url + '?palette=' + color_palette;
+            return HeatmapViewerService.getDatasetBaseUrl() + '?palette=' + color_palette;
         }
 
         function getStaticFilesURL() {
@@ -469,8 +468,8 @@
                 clinical_annotation_step_label);
         }
 
-        function registerHeatmapComponents(viewer_manager, dataset_base_url) {
-            HeatmapViewerService.registerComponents(viewer_manager, dataset_base_url);
+        function registerHeatmapComponents(viewer_manager) {
+            HeatmapViewerService.registerComponents(viewer_manager, vm.ome_base_url, vm.prediction_details);
         }
 
         function setOverlayOpacity(opacity, update) {

--- a/promort/src/js/ome_seadragon_viewer/viewer.directives.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.directives.js
@@ -270,12 +270,12 @@
                         ome_seadragon_viewer.setMinDZILevel(8);
 
                         if(scope.avc.enableHeatmapLayer()) {
+                            scope.avc.registerHeatmapComponents(ome_seadragon_viewer);
                             ome_seadragon_viewer.initOverlaysLayer(
                                 {
                                     'green': scope.avc.getDatasetDZIURL('Greens_9')
                                 }, 0.5
                             );
-                            scope.avc.registerHeatmapComponents(ome_seadragon_viewer, scope.avc.dataset_dzi_url);
                             scope.avc.setOverlayOpacity(0.5);
 
                             ome_seadragon_viewer.activateOverlay('green');

--- a/promort/src/js/ome_seadragon_viewer/viewer.directives.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.directives.js
@@ -244,6 +244,16 @@
                     );
                     ome_seadragon_viewer.buildViewer();
 
+                    ome_seadragon_viewer.viewer.world.addHandler('add-item', function(data) {
+                        scope.$broadcast('viewer.tiledimage.added');
+
+                        data.item.addHandler('fully-loaded-change', function(data) {
+                            if (data.fullyLoaded === true) {
+                                scope.$broadcast('viewer.tiledimage.loaded');
+                            }
+                        });
+                    });
+
                     var scalebar_config = {
                         'xOffset': 10,
                         'yOffset': 10,
@@ -258,6 +268,18 @@
 
                     ome_seadragon_viewer.viewer.addHandler('open', function() {
                         ome_seadragon_viewer.setMinDZILevel(8);
+
+                        if(scope.avc.enableHeatmapLayer()) {
+                            ome_seadragon_viewer.initOverlaysLayer(
+                                {
+                                    'green': scope.avc.getDatasetDZIURL('Greens_9')
+                                }, 0.5
+                            );
+                            scope.avc.registerHeatmapComponents(ome_seadragon_viewer, scope.avc.dataset_dzi_url);
+                            scope.avc.setOverlayOpacity(0.5);
+
+                            ome_seadragon_viewer.activateOverlay('green');
+                        }
 
                         var annotations_canvas = new AnnotationsController('rois_canvas');
                         annotations_canvas.buildAnnotationsCanvas(ome_seadragon_viewer);

--- a/promort/src/js/ome_seadragon_viewer/viewer.directives.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.directives.js
@@ -278,7 +278,7 @@
                             );
                             scope.avc.setOverlayOpacity(0.5);
 
-                            ome_seadragon_viewer.activateOverlay('green');
+                            ome_seadragon_viewer.activateOverlay('green', '0.5');
                         }
 
                         var annotations_canvas = new AnnotationsController('rois_canvas');

--- a/promort/src/js/ome_seadragon_viewer/viewer.directives.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.directives.js
@@ -211,7 +211,7 @@
             link: function(scope, element, attrs) {
                 function setViewerHeight() {
                     var used_v_space = $("#pg_header").height() + $("#pg_footer").height()
-                        + $("#index_navbar").height() + 100;
+                        + $("#index_navbar").height() + $("#heatmap_controls").height() + 115;
 
                     var available_v_space = $(window).height() - used_v_space;
 

--- a/promort/src/js/ome_seadragon_viewer/viewer.directives.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.directives.js
@@ -273,12 +273,12 @@
                             scope.avc.registerHeatmapComponents(ome_seadragon_viewer);
                             ome_seadragon_viewer.initOverlaysLayer(
                                 {
-                                    'green': scope.avc.getDatasetDZIURL('Greens_9')
+                                    'red': scope.avc.getDatasetDZIURL('Reds_9')
                                 }, 0.5
                             );
                             scope.avc.setOverlayOpacity(0.5);
 
-                            ome_seadragon_viewer.activateOverlay('green', '0.5');
+                            ome_seadragon_viewer.activateOverlay('red', '0.5');
                         }
 
                         var annotations_canvas = new AnnotationsController('rois_canvas');

--- a/promort/src/js/ome_seadragon_viewer/viewer.services.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.services.js
@@ -125,7 +125,8 @@
                 {'params' :{
                     'threshold': threshold, 
                     'cluster_min_distance': cluster_size,
-                    'cluster_min_area': 2
+                    'cluster_min_area': 2,
+                    'shape_mode': 'patch'
                 }}
             );
         }

--- a/promort/src/js/ome_seadragon_viewer/viewer.services.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.services.js
@@ -92,20 +92,36 @@
         var HeatmapViewerService = {
             registerComponents: registerComponents,
             getPredictionInfo: getPredictionInfo,
+            getDatasetBaseUrl: getDatasetBaseUrl,
+            getShapedFromDatasetBaseUrl: getShapedFromDatasetBaseUrl,
+            getShapesFromPrediction: getShapesFromPrediction,
             setOverlay: setOverlay,
             setOverlayOpacity: setOverlayOpacity
         };
 
         return HeatmapViewerService;
 
-        function registerComponents(viewer_manager, dataset_base_url) {
+        function registerComponents(viewer_manager, ome_base_url, prediction_details) {
             this.viewerManager = viewer_manager;
-            this.dataset_base_url = dataset_base_url;
-            $rootScope.$broadcast('viewerctrl.components.registered');
+            this.dataset_base_url = ome_base_url + 'arrays/deepzoom/get/' + prediction_details.omero_id + '.dzi';
+            this.dataset_shapes_base_url = ome_base_url + 'arrays/shapes/get/' + prediction_details.omero_id;
+            $rootScope.$broadcast('hm_viewerctrl.components.registered');
         }
 
         function getPredictionInfo(prediction_id) {
             return $http.get('api/predictions/' + prediction_id + '/');
+        }
+
+        function getDatasetBaseUrl() {
+            return this.dataset_base_url;
+        }
+
+        function getShapedFromDatasetBaseUrl() {
+            return this.dataset_shapes_base_url;
+        }
+
+        function getShapesFromPrediction(threshold) {
+            return $http.get(this.dataset_shapes_base_url, {'params' :{'threshold': threshold}});
         }
 
         function setOverlay(palette, threshold) {
@@ -199,6 +215,7 @@
         }
 
         function drawShape(shape_json) {
+            console.log(shape_json);
             this.roisManager.drawShapeFromJSON(shape_json);
         }
 

--- a/promort/src/js/ome_seadragon_viewer/viewer.services.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.services.js
@@ -122,7 +122,12 @@
 
         function getShapesFromPrediction(threshold, cluster_size) {
             return $http.get(this.dataset_shapes_base_url, 
-                {'params' :{'threshold': threshold, 'cluster_size_percent': cluster_size}});
+                {'params' :{
+                    'threshold': threshold, 
+                    'cluster_min_distance': cluster_size,
+                    'cluster_min_area': 2
+                }}
+            );
         }
 
         function setOverlay(palette, threshold) {

--- a/promort/src/js/ome_seadragon_viewer/viewer.services.js
+++ b/promort/src/js/ome_seadragon_viewer/viewer.services.js
@@ -120,8 +120,9 @@
             return this.dataset_shapes_base_url;
         }
 
-        function getShapesFromPrediction(threshold) {
-            return $http.get(this.dataset_shapes_base_url, {'params' :{'threshold': threshold}});
+        function getShapesFromPrediction(threshold, cluster_size) {
+            return $http.get(this.dataset_shapes_base_url, 
+                {'params' :{'threshold': threshold, 'cluster_size_percent': cluster_size}});
         }
 
         function setOverlay(palette, threshold) {

--- a/promort/src/js/predictions_manager/predictions_manager.services.js
+++ b/promort/src/js/predictions_manager/predictions_manager.services.js
@@ -36,6 +36,7 @@
 
         var CurrentPredictionDetailsService = {
             getPredictionByReviewStep: getPredictionByReviewStep,
+            getLatestPredictionBySlide: getLatestPredictionBySlide,
             registerCurrentPrediction: registerCurrentPrediction,
             getPredictionId: getPredictionId,
             getSlideId: getSlideId,
@@ -50,6 +51,15 @@
             caseID = undefined;
 
             return $http.get('api/prediction_review/' + review_step_label + '/prediction/');
+        }
+
+        function getLatestPredictionBySlide(slide_id, type) {
+            predictionID = undefined;
+            slideID = undefined;
+            caseID = undefined;
+
+            return $http.get('api/slides/' + slide_id + '/predictions/',
+                             {'params': {'latest': true, 'type': type}});
         }
 
         function registerCurrentPrediction(prediction_id, slide_id, case_id) {

--- a/promort/src/js/rois_manager/rois_manager.controllers.js
+++ b/promort/src/js/rois_manager/rois_manager.controllers.js
@@ -56,6 +56,7 @@
         vm.overlay_palette = undefined;
         vm.overlay_opacity = undefined;
         vm.overlay_threshold = undefined;
+        vm.navmap_cluster_size = undefined;
 
         vm.oo_percentage = undefined;
 
@@ -151,6 +152,7 @@
 
         vm.updateOverlayOpacity = updateOverlayOpacity;
         vm.updateOverlayThreshold = updateOverlayThreshold;
+        vm.updateNavmapClusterSize = updateNavmapClusterSize;
         vm.updateOverlayPalette = updateOverlayPalette;
 
         activate();
@@ -168,7 +170,8 @@
 
             vm.overlay_palette = 'Greens_9';
             vm.overlay_opacity = 0.5;
-            vm.overlay_threshold = "0.0";
+            vm.overlay_threshold = "0.5";
+            vm.navmap_cluster_size = "2";
 
             vm.oo_percentage = Math.floor(vm.overlay_opacity * 100);
 
@@ -199,7 +202,7 @@
                         function() {
                             // load navigation map
                             $log.info('Building navigation map');
-                            HeatmapViewerService.getShapesFromPrediction(vm.overlay_threshold)
+                            HeatmapViewerService.getShapesFromPrediction(vm.overlay_threshold, vm.navmap_cluster_size)
                                 .then(getShapesSuccessFn, getShapesErrorFn);
 
                             function getShapesSuccessFn(response) {
@@ -891,7 +894,21 @@
         function updateOverlayThreshold() {
             HeatmapViewerService.setOverlay(vm.overlay_palette, vm.overlay_threshold);
 
-            HeatmapViewerService.getShapesFromPrediction(vm.overlay_threshold)
+            HeatmapViewerService.getShapesFromPrediction(vm.overlay_threshold, vm.navmap_cluster_size)
+                                .then(getShapesSuccessFn, getShapesErrorFn);
+
+            function getShapesSuccessFn(response) {
+                vm._updateNavmap(response.data.shapes);
+            }
+
+            function getShapesErrorFn(response) {
+                $log.error('Error when loading shapes from prediction');
+                $log.error(response);
+            }
+        }
+
+        function updateNavmapClusterSize() {
+            HeatmapViewerService.getShapesFromPrediction(vm.overlay_threshold, vm.navmap_cluster_size)
                                 .then(getShapesSuccessFn, getShapesErrorFn);
 
             function getShapesSuccessFn(response) {

--- a/promort/src/js/rois_manager/rois_manager.controllers.js
+++ b/promort/src/js/rois_manager/rois_manager.controllers.js
@@ -174,9 +174,9 @@
 
             vm.prediction_id = CurrentPredictionDetailsService.getPredictionId();
 
-            vm.overlay_palette = 'Greens_9';
+            vm.overlay_palette = 'Reds_9';
             vm.overlay_opacity = 0.5;
-            vm.overlay_threshold = "0.5";
+            vm.overlay_threshold = "0.8";
             vm.navmap_cluster_size = "2";
 
             vm.oo_percentage = Math.floor(vm.overlay_opacity * 100);
@@ -3046,8 +3046,8 @@
             vm.slide_id = CurrentSlideDetailsService.getSlideId();
             vm.case_id = CurrentSlideDetailsService.getCaseId();
 
-            // by default, mark region as NORMAL
-            vm.tissueStatus = 'NORMAL';
+            // by default, mark region as TUMOR
+            vm.tissueStatus = 'TUMOR';
 
             vm.regionLengthScaleFactor = vm.lengthUOM[0];
             vm.regionAreaScaleFactor = vm.areaUOM[0];

--- a/promort/src/js/rois_manager/rois_manager.controllers.js
+++ b/promort/src/js/rois_manager/rois_manager.controllers.js
@@ -63,6 +63,8 @@
         vm.cores_map = undefined;
         vm.focus_regions_map = undefined;
 
+        vm.displayNavmap = undefined;
+
         vm.navmap_items = undefined;
         vm.navmap_items_label = undefined;
 
@@ -85,9 +87,14 @@
         vm._createNewSubtree = _createNewSubtree;
         vm._lockRoisTree = _lockRoisTree;
         vm._unlockRoisTree = _unlockRoisTree;
-        vm._buildNavmapItem = _buildNavmapItem;
-        vm._buildNavmap = _buildNavmap;
+        vm._drawNavmapItem = _drawNavmapItem;
+        vm._drawNavmap = _drawNavmap;
+        vm._deleteNavmapItem = _deleteNavmapItem;
+        vm._hideNavmap = _hideNavmap;
+        vm._clearNavmap = _clearNavmap;
         vm._updateNavmap = _updateNavmap;
+        vm.navmapDisplayEnabled = navmapDisplayEnabled;
+        vm.switchNavmapDisplay = switchNavmapDisplay;
         vm.jumpToNextNavmapItem = jumpToNextNavmapItem;
         vm.jumpToPreviousNavmapItem = jumpToPreviousNavmapItem;
         vm.jumpToNavmapItem = jumpToNavmapItem;
@@ -169,17 +176,13 @@
             vm.cores_map = {};
             vm.focus_regions_map = {};
 
+            vm.displayNavmap = false;
             vm.navmap_items = {};
             vm.navmap_items_label = [];
 
             $rootScope.slices = [];
             $rootScope.cores = [];
             $rootScope.focus_regions = [];
-
-            $("#navmap_item").mouseover(function(e){
-                console.log('Event on navmap_item');
-                console.log($(e.target));
-            });
 
             ROIsAnnotationStepService.getDetails(vm.annotation_step_label)
                 .then(getROIsAnnotationStepSuccessFn, getROIsAnnotationStepErrorFn);
@@ -203,7 +206,6 @@
                                 for (var sh in response.data.shapes) {
                                     vm._registerNavmapItem(sh, response.data.shapes[sh]);
                                 }
-                                vm._buildNavmap();
                             }
 
                             function getShapesErrorFn(response) {
@@ -458,14 +460,20 @@
             $(".prm-tree-el").removeClass("prm-tree-el-disabled");
         }
 
-        function _buildNavmapItem(item_label, item_shape) {
+        function _drawNavmapItem(item_label, hidden) {
+            if (hidden==true) {
+                var stroke_alpha = 0;
+            } else {
+                var stroke_alpha = 1;
+            }
+            var item_shape = vm.navmap_items[item_label];
             var shape_json = {
                 'shape_id': item_label,
-                'fill_color': '#0000ff',
-                'fill_alpha': 0.3,
+                'fill_color': '#fff',
+                'fill_alpha': 0.0,
                 'stroke_color': '#0000ff',
-                'stroke_alpha': 1,
-                'stroke_width': 100,
+                'stroke_alpha': stroke_alpha,
+                'stroke_width': 50,
                 'hidden': false,
                 'segments': item_shape,
                 'type': 'polygon'
@@ -473,36 +481,78 @@
             AnnotationsViewerService.drawShape(shape_json);
         }
 
-        function _buildNavmap() {
+        function _deleteNavmapItem(item_label) {
+            AnnotationsViewerService.deleteShape(item_label);
+        }
+
+        function _drawNavmap() {
             for (var ilabel in vm.navmap_items) {
-                vm._buildNavmapItem(ilabel, vm.navmap_items[ilabel]);
+                vm._drawNavmapItem(ilabel, false);
             }
         }
 
-        function _updateNavmap(new_shapes) {
+        function _hideNavmap() {
             for (var sh in vm.navmap_items) {
-                AnnotationsViewerService.deleteShape(sh);
+                vm._deleteNavmapItem(sh);
+            }
+        }
+
+        function _clearNavmap() {
+            for (var sh in vm.navmap_items) {
+                vm._deleteNavmapItem(sh);
             }
             vm.navmap_items = {};
             vm.navmap_items_label = [];
             vm.navmap_selected_item = undefined;
+        }
+
+        function _updateNavmap(new_shapes) {
+            vm._clearNavmap();
             $("#selected_navmap_item").text("-- Select an item --");
             for (var sh in new_shapes) {
                 vm._registerNavmapItem(sh, new_shapes[sh]);
             }
-            vm._buildNavmap();
+            if (vm.navmapDisplayEnabled()) {
+                vm._drawNavmap();
+            }
+        }
+
+        function navmapDisplayEnabled() {
+            return vm.displayNavmap;
+        }
+
+        function switchNavmapDisplay() {
+            console.log('Switching navmap display');
+            vm.displayNavmap = !vm.displayNavmap;
+            if (vm.navmapDisplayEnabled()) {
+                console.log('Draw navmap');
+                vm._drawNavmap();
+            } else {
+                console.log('Hide navmap');
+                vm._hideNavmap();
+            }
         }
 
         function jumpToNextNavmapItem() {
-            vm.jumpToNavmapItem(
-                vm.navmap_items_label[vm.navmap_items_label.indexOf(vm.navmap_selected_item)+1]
-            );
+            var next_item_label = vm.navmap_items_label[vm.navmap_items_label.indexOf(vm.navmap_selected_item)+1];
+            if(!vm.navmapDisplayEnabled()) {
+                vm._drawNavmapItem(next_item_label, true);
+            }
+            vm.jumpToNavmapItem(next_item_label);
+            if(!vm.navmapDisplayEnabled()) {
+                vm._deleteNavmapItem(next_item_label);
+            }
         }
 
         function jumpToPreviousNavmapItem() {
-            vm.jumpToNavmapItem(
-                vm.navmap_items_label[vm.navmap_items_label.indexOf(vm.navmap_selected_item)-1]
-            );
+            var prev_item_label = vm.navmap_items_label[vm.navmap_items_label.indexOf(vm.navmap_selected_item)-1];
+            if(!vm.navmapDisplayEnabled()) {
+                vm._drawNavmapItem(prev_item_label, true);
+            }
+            vm.jumpToNavmapItem(prev_item_label);
+            if(!vm.navmapDisplayEnabled()) {
+                vm._deleteNavmapItem(prev_item_label);
+            }
         }
 
         function jumpToNavmapItem(label) {
@@ -532,11 +582,17 @@
         }
 
         function selectNavmapItem(label) {
+            if(!vm.navmapDisplayEnabled()) {
+                vm._drawNavmapItem(label, true);
+            }
             AnnotationsViewerService.selectShape(label);
         }
 
         function deselectNavmapItem(label) {
             AnnotationsViewerService.deselectShape(label);
+            if(!vm.navmapDisplayEnabled()) {
+                vm._deleteNavmapItem(label);
+            }
         }
 
         function isFirstItemSelected() {

--- a/promort/src/js/rois_manager/rois_manager.controllers.js
+++ b/promort/src/js/rois_manager/rois_manager.controllers.js
@@ -100,7 +100,6 @@
         vm._updateNavmap = _updateNavmap;
         vm.navmapDisplayEnabled = navmapDisplayEnabled;
         vm.switchNavmapDisplay = switchNavmapDisplay;
-        vm.disableNavmapFilter = disableNavmapFilter;
         vm.removeSliceNavmapFilter = removeSliceNavmapFilter;
         vm.filterNavmapBySlice = filterNavmapBySlice;
         vm.jumpToNextNavmapItem = jumpToNextNavmapItem;
@@ -570,10 +569,6 @@
                 console.log('Hide navmap');
                 vm._hideNavmap();
             }
-        }
-
-        function disableNavmapFilter() {
-            return Object.keys(vm.slices_map).length === 0;
         }
 
         function removeSliceNavmapFilter() {

--- a/promort/src/js/rois_manager/rois_manager.controllers.js
+++ b/promort/src/js/rois_manager/rois_manager.controllers.js
@@ -66,10 +66,12 @@
 
         vm.displayNavmap = undefined;
 
+        vm.full_navmap_items = undefined;
         vm.navmap_items = undefined;
         vm.navmap_items_label = undefined;
 
         vm.navmap_selected_item = undefined;
+        vm.navmap_selected_filter = undefined;
 
         vm.ui_active_modes = {
             'new_slice': false,
@@ -88,14 +90,19 @@
         vm._createNewSubtree = _createNewSubtree;
         vm._lockRoisTree = _lockRoisTree;
         vm._unlockRoisTree = _unlockRoisTree;
+        vm._drawNavmapCluster = _drawNavmapCluster;
         vm._drawNavmapItem = _drawNavmapItem;
         vm._drawNavmap = _drawNavmap;
         vm._deleteNavmapItem = _deleteNavmapItem;
         vm._hideNavmap = _hideNavmap;
         vm._clearNavmap = _clearNavmap;
+        vm._filterNavmapByShape = _filterNavmapByShape;
         vm._updateNavmap = _updateNavmap;
         vm.navmapDisplayEnabled = navmapDisplayEnabled;
         vm.switchNavmapDisplay = switchNavmapDisplay;
+        vm.disableNavmapFilter = disableNavmapFilter;
+        vm.removeSliceNavmapFilter = removeSliceNavmapFilter;
+        vm.filterNavmapBySlice = filterNavmapBySlice;
         vm.jumpToNextNavmapItem = jumpToNextNavmapItem;
         vm.jumpToPreviousNavmapItem = jumpToPreviousNavmapItem;
         vm.jumpToNavmapItem = jumpToNavmapItem;
@@ -180,8 +187,12 @@
             vm.focus_regions_map = {};
 
             vm.displayNavmap = false;
+            vm.full_navmap_items = {}
             vm.navmap_items = {};
             vm.navmap_items_label = [];
+
+            vm.navmap_selected_item = undefined;
+            vm.navmap_selected_filter = undefined;
 
             $rootScope.slices = [];
             $rootScope.cores = [];
@@ -208,6 +219,8 @@
                             function getShapesSuccessFn(response) {
                                 for (var sh in response.data.shapes) {
                                     vm._registerNavmapItem(sh, response.data.shapes[sh]);
+                                    vm.navmap_items = vm.full_navmap_items;
+                                    vm.navmap_items_label = Object.keys(vm.navmap_items);
                                 }
                             }
 
@@ -360,8 +373,7 @@
 
         function _registerNavmapItem(item_index, item_shape) {
             var item_label = 'cluster_' + (parseInt(item_index)+1);
-            vm.navmap_items[item_label] = item_shape;
-            vm.navmap_items_label.push(item_label);
+            vm.full_navmap_items[item_label] = item_shape;
         }
 
         function _registerSlice(slice_info) {
@@ -463,13 +475,12 @@
             $(".prm-tree-el").removeClass("prm-tree-el-disabled");
         }
 
-        function _drawNavmapItem(item_label, hidden) {
+        function _drawNavmapCluster(item_label, item_shape, hidden) {
             if (hidden==true) {
                 var stroke_alpha = 0;
             } else {
                 var stroke_alpha = 1;
             }
-            var item_shape = vm.navmap_items[item_label];
             var shape_json = {
                 'shape_id': item_label,
                 'fill_color': '#fff',
@@ -482,6 +493,11 @@
                 'type': 'polygon'
             };
             AnnotationsViewerService.drawShape(shape_json);
+        }
+
+        function _drawNavmapItem(item_label, hidden) {
+            var item_shape = vm.navmap_items[item_label];
+            vm._drawNavmapCluster(item_label, item_shape, hidden);
         }
 
         function _deleteNavmapItem(item_label) {
@@ -500,20 +516,40 @@
             }
         }
 
-        function _clearNavmap() {
+        function _clearNavmap(keep_source) {
             for (var sh in vm.navmap_items) {
                 vm._deleteNavmapItem(sh);
+            }
+            if (!keep_source) {
+                vm.full_navmap_items = {};
             }
             vm.navmap_items = {};
             vm.navmap_items_label = [];
             vm.navmap_selected_item = undefined;
         }
 
+        function _filterNavmapByShape(shape_label) {
+            for (var ilabel in vm.full_navmap_items) {
+                vm._drawNavmapCluster(ilabel, vm.full_navmap_items[ilabel], true);
+                if (AnnotationsViewerService.checkContainment(shape_label, ilabel)) {
+                    vm.navmap_items[ilabel] = vm.full_navmap_items[ilabel];
+                    vm.navmap_items_label.push(ilabel);
+                }
+                vm._deleteNavmapItem(ilabel);
+            }
+        }
+
         function _updateNavmap(new_shapes) {
-            vm._clearNavmap();
+            vm._clearNavmap(false);
             $("#selected_navmap_item").text("-- Select an item --");
             for (var sh in new_shapes) {
                 vm._registerNavmapItem(sh, new_shapes[sh]);
+            }
+            if (typeof(vm.navmap_selected_filter) !== 'undefined') {
+                vm._filterNavmapByShape(vm.navmap_selected_filter);
+            } else {
+                vm.navmap_items = vm.full_navmap_items;
+                vm.navmap_items_label = Object.keys(vm.navmap_items);
             }
             if (vm.navmapDisplayEnabled()) {
                 vm._drawNavmap();
@@ -533,6 +569,31 @@
             } else {
                 console.log('Hide navmap');
                 vm._hideNavmap();
+            }
+        }
+
+        function disableNavmapFilter() {
+            return Object.keys(vm.slices_map).length === 0;
+        }
+
+        function removeSliceNavmapFilter() {
+            vm._clearNavmap(true);
+            vm.navmap_items = vm.full_navmap_items;
+            vm.navmap_items_label = Object.keys(vm.navmap_items);
+            if (vm.navmapDisplayEnabled()) {
+                vm._drawNavmap();
+            }
+            vm.navmap_selected_filter = undefined;
+            $("#selected_slice_filter").text("-- No filter --");
+        }
+
+        function filterNavmapBySlice(slice) {
+            vm._clearNavmap(true);
+            vm._filterNavmapByShape(slice);
+            vm.navmap_selected_filter = slice;
+            $("#selected_slice_filter").text(vm.navmap_selected_filter);
+            if (vm.navmapDisplayEnabled()) {
+                vm._drawNavmap();
             }
         }
 

--- a/promort/src/js/rois_manager/rois_manager.controllers.js
+++ b/promort/src/js/rois_manager/rois_manager.controllers.js
@@ -64,6 +64,9 @@
         vm.focus_regions_map = undefined;
 
         vm.navmap_items = undefined;
+        vm.navmap_items_label = undefined;
+
+        vm.navmap_selected_item = undefined;
 
         vm.ui_active_modes = {
             'new_slice': false,
@@ -85,6 +88,17 @@
         vm._buildNavmapItem = _buildNavmapItem;
         vm._buildNavmap = _buildNavmap;
         vm._updateNavmap = _updateNavmap;
+        vm.jumpToNextNavmapItem = jumpToNextNavmapItem;
+        vm.jumpToPreviousNavmapItem = jumpToPreviousNavmapItem;
+        vm.jumpToNavmapItem = jumpToNavmapItem;
+        vm.jumpToSelectedNavmapItem = jumpToSelectedNavmapItem;
+        vm.noNavmapItemSelected = noNavmapItemSelected;
+        vm.showSelectedNavmapItem = showSelectedNavmapItem;
+        vm.hideSelectedNavmapItem = hideSelectedNavmapItem;
+        vm.selectNavmapItem = selectNavmapItem;
+        vm.deselectNavmapItem = deselectNavmapItem;
+        vm.isFirstItemSelected = isFirstItemSelected;
+        vm.isLastItemSelected = isLastItemSelected;
         vm.allModesOff = allModesOff;
         vm.showROI = showROI;
         vm.editROI = editROI;
@@ -156,10 +170,16 @@
             vm.focus_regions_map = {};
 
             vm.navmap_items = {};
+            vm.navmap_items_label = [];
 
             $rootScope.slices = [];
             $rootScope.cores = [];
             $rootScope.focus_regions = [];
+
+            $("#navmap_item").mouseover(function(e){
+                console.log('Event on navmap_item');
+                console.log($(e.target));
+            });
 
             ROIsAnnotationStepService.getDetails(vm.annotation_step_label)
                 .then(getROIsAnnotationStepSuccessFn, getROIsAnnotationStepErrorFn);
@@ -334,8 +354,9 @@
         }
 
         function _registerNavmapItem(item_index, item_shape) {
-            var item_label = 'cluster_' + (item_index+1);
+            var item_label = 'cluster_' + (parseInt(item_index)+1);
             vm.navmap_items[item_label] = item_shape;
+            vm.navmap_items_label.push(item_label);
         }
 
         function _registerSlice(slice_info) {
@@ -463,10 +484,67 @@
                 AnnotationsViewerService.deleteShape(sh);
             }
             vm.navmap_items = {};
+            vm.navmap_items_label = [];
+            vm.navmap_selected_item = undefined;
+            $("#selected_navmap_item").text("-- Select an item --");
             for (var sh in new_shapes) {
                 vm._registerNavmapItem(sh, new_shapes[sh]);
             }
             vm._buildNavmap();
+        }
+
+        function jumpToNextNavmapItem() {
+            vm.jumpToNavmapItem(
+                vm.navmap_items_label[vm.navmap_items_label.indexOf(vm.navmap_selected_item)+1]
+            );
+        }
+
+        function jumpToPreviousNavmapItem() {
+            vm.jumpToNavmapItem(
+                vm.navmap_items_label[vm.navmap_items_label.indexOf(vm.navmap_selected_item)-1]
+            );
+        }
+
+        function jumpToNavmapItem(label) {
+            vm.navmap_selected_item = label;
+            $("#selected_navmap_item").text(label);
+            vm.jumpToSelectedNavmapItem();
+        }
+
+        function jumpToSelectedNavmapItem() {
+            AnnotationsViewerService.focusOnShape(vm.navmap_selected_item);
+        }
+
+        function noNavmapItemSelected() {
+            return vm.navmap_selected_item == undefined;
+        }
+
+        function showSelectedNavmapItem() {
+            if(!vm.noNavmapItemSelected()) {
+                vm.selectNavmapItem(vm.navmap_selected_item);
+            }
+        }
+
+        function hideSelectedNavmapItem() {
+            if(!vm.noNavmapItemSelected()) {
+                vm.deselectNavmapItem(vm.navmap_selected_item);
+            }
+        }
+
+        function selectNavmapItem(label) {
+            AnnotationsViewerService.selectShape(label);
+        }
+
+        function deselectNavmapItem(label) {
+            AnnotationsViewerService.deselectShape(label);
+        }
+
+        function isFirstItemSelected() {
+            return (vm.navmap_items_label.indexOf(vm.navmap_selected_item) == 0);
+        }
+
+        function isLastItemSelected() {
+            return (vm.navmap_items_label.indexOf(vm.navmap_selected_item) == (vm.navmap_items_label.length - 1));
         }
 
         function allModesOff() {

--- a/promort/src/js/rois_manager/rois_manager.controllers.js
+++ b/promort/src/js/rois_manager/rois_manager.controllers.js
@@ -38,11 +38,12 @@
 
     ROIsManagerController.$inject = ['$scope', '$routeParams', '$rootScope', '$compile', '$location', '$log',
         'ngDialog', 'ROIsAnnotationStepService', 'ROIsAnnotationStepManagerService',
-        'AnnotationsViewerService', 'CurrentSlideDetailsService'];
+        'AnnotationsViewerService', 'CurrentSlideDetailsService', 'CurrentPredictionDetailsService'];
 
     function ROIsManagerController($scope, $routeParams, $rootScope, $compile, $location, $log, ngDialog,
                                    ROIsAnnotationStepService, ROIsAnnotationStepManagerService,
-                                   AnnotationsViewerService, CurrentSlideDetailsService) {
+                                   AnnotationsViewerService, CurrentSlideDetailsService,
+                                   CurrentPredictionDetailsService) {
         var vm = this;
         vm.slide_id = undefined;
         vm.slide_index = undefined;
@@ -116,6 +117,8 @@
         activate();
 
         function activate() {
+            console.log("Prediction ID: " + CurrentPredictionDetailsService.getPredictionId());
+
             vm.slide_id = CurrentSlideDetailsService.getSlideId();
             vm.case_id = CurrentSlideDetailsService.getCaseId();
             vm.annotation_step_label = $routeParams.label;

--- a/promort/src/js/rois_manager/rois_manager.services.js
+++ b/promort/src/js/rois_manager/rois_manager.services.js
@@ -54,10 +54,15 @@
         }
 
         function getROIs(step_label, read_only, clinical_step_label) {
-            if (!read_only) {
-                return $http.get('/api/rois_annotation_steps/' + step_label + '/rois_list/');
+            $log.info('Called getROIs service with params: ' + step_label + ' ' + read_only + ' ' + clinical_step_label);
+            if(typeof(read_only) == 'undefined') {
+                $log.error('missing required parameter');
             } else {
-                return $http.get('/api/rois_annotation_steps/' + step_label + '/rois_list/' + clinical_step_label + '/');
+                if (!read_only) {
+                    return $http.get('/api/rois_annotation_steps/' + step_label + '/rois_list/');
+                } else {
+                    return $http.get('/api/rois_annotation_steps/' + step_label + '/rois_list/' + clinical_step_label + '/');
+                }
             }
         }
 

--- a/promort/src/js/slides_manager/slides_manager.controllers.js
+++ b/promort/src/js/slides_manager/slides_manager.controllers.js
@@ -27,10 +27,12 @@
         .controller('QualityControlController', QualityControlController);
 
     QualityControlController.$inject = ['$scope', '$routeParams', '$location', '$log', 'Authentication',
-        'SlideEvaluationService', 'ROIsAnnotationStepService', 'SlideService', 'CurrentSlideDetailsService'];
+        'SlideEvaluationService', 'ROIsAnnotationStepService', 'SlideService', 'CurrentSlideDetailsService',
+        'CurrentPredictionDetailsService'];
 
     function QualityControlController($scope, $routeParams, $location, $log, Authentication, SlideEvaluationService,
-                                      ROIsAnnotationStepService, SlideService, CurrentSlideDetailsService) {
+                                      ROIsAnnotationStepService, SlideService, CurrentSlideDetailsService,
+                                      CurrentPredictionDetailsService) {
         var vm = this;
         vm.annotation_label = undefined;
         vm.annotation_step_label = undefined;
@@ -75,7 +77,26 @@
                     }
                 } else {
                     if (response.data.slide_evaluation.adequate_slide) {
-                        $location.url('worklist/' + vm.annotation_step_label + '/rois_manager');
+                        console.log('Getting prediction details');
+                        CurrentPredictionDetailsService.getLatestPredictionBySlide(CurrentSlideDetailsService.getSlideId(), 'TUMOR')
+                            .then(getPredictionSuccessFn, getPredictionErrorFn);
+
+                        function getPredictionSuccessFn(response) {
+                            CurrentPredictionDetailsService.registerCurrentPrediction(
+                                response.data.id, response.data.slide,
+                                CurrentSlideDetailsService.getCaseId()
+                            );
+                            $location.url('worklist/' + vm.annotation_step_label + '/rois_manager');
+                        }
+
+                        function getPredictionErrorFn(response) {
+                            if(response.status == 404) {
+                                $location.url('worklist/' + vm.annotation_step_label + '/rois_manager');
+                            } else {
+                                $log.error('Error when loading predictions');
+                                $log.error(response);
+                            }
+                        }
                     } else {
                         $location.url('worklist/' + vm.annotation_label);
                     }
@@ -126,7 +147,27 @@
 
                     //noinspection JSAnnotator
                     function startAnnotationSuccessFn(response) {
-                        $location.url('worklist/' + vm.annotation_step_label + '/rois_manager');
+                        console.log('Getting prediction details');
+                        CurrentPredictionDetailsService.getLatestPredictionBySlide(CurrentSlideDetailsService.getSlideId(), 'TUMOR')
+                            .then(getPredictionSuccessFn, getPredictionErrorFn);
+
+                        function getPredictionSuccessFn(response) {
+                            console.log('Prediction details: ' + response.data);
+                            CurrentPredictionDetailsService.registerCurrentPrediction(
+                                response.data.id, response.data.slide,
+                                CurrentSlideDetailsService.getCaseId()
+                            );
+                            $location.url('worklist/' + vm.annotation_step_label + '/rois_manager');
+                        }
+
+                        function getPredictionErrorFn(response) {
+                            if(response.status == 404) {
+                                $location.url('worklist/' + vm.annotation_step_label + '/rois_manager');
+                            } else {
+                                $log.error('Error when loading predictions');
+                                $log.error(response);
+                            }
+                        }
                     }
 
                     //noinspection JSAnnotator

--- a/promort/static_src/css/promort.css
+++ b/promort/static_src/css/promort.css
@@ -305,6 +305,19 @@ h3.prm-dialog-container {
     transform: scale(-1, 1);
 }
 
+.prm-hm-controls {
+    background-color: white;
+    margin-top: 0;
+    margin-bottom: 5px;
+    padding-top: 10px;
+    padding-bottom: 0;
+}
+
+#navigation_map_controls {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
 /* Hidden placeholder */
 select option[disabled]:first-child {
     display: none;

--- a/promort/static_src/css/promort.css
+++ b/promort/static_src/css/promort.css
@@ -27,6 +27,7 @@ div.prm-valign {
 
 div.prm-viewer_frame {
     background-color: white;
+    padding: 5px;
 }
 
 div.prm-ome_viewer_simple {

--- a/promort/static_src/css/promort.css
+++ b/promort/static_src/css/promort.css
@@ -172,6 +172,12 @@ h3.prm-dialog-container {
     height: 30px;
 }
 
+.prm-full-col-btn {
+    display: block;
+    width: 100%;
+    text-align: center;
+}
+
 .prm-icon-btn-ruler {
     margin-left: 4px !important;
     border-radius: 4px !important;

--- a/promort/static_src/templates/rois_manager/focus_region.html
+++ b/promort/static_src/templates/rois_manager/focus_region.html
@@ -283,9 +283,9 @@
             <select class="form-control" id="tissueStatus" ng-model="rmCtrl.tissueStatus"
                     ng-change="rmCtrl.switchShapeColor()"
                     ng-disabled="rmCtrl.isReadOnly() || rmCtrl.isRulerToolActive()">
-                <option value="NORMAL" selected>Normal</option>
+                <option value="NORMAL">Normal</option>
                 <option value="STRESSED">Stressed</option>
-                <option value="TUMOR">Tumor</option>
+                <option value="TUMOR" selected="selected">Tumor</option>
             </select>
         </fieldset>
     </div>

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -27,19 +27,21 @@
             <a href="worklist/rois_annotations/{{ rmc.annotation_label }}" role="button" class="btn btn-default">
                 <i class="icon-arrow_big_left"></i> Back to slides
             </a>
-            <div class="btn-group dropdown">
-                <button class="btn btn-default dropdown-toggle" data-toggle="dropdown"
-                        ng-disabled="rmc.newItemCreationModeActive() || rmc.editItemModeActive()">
-                    <i class="icon-plus"></i> New item <i class="icon-play prm-rotate-90 prm-caret"></i>
-                </button>
-                <ul class="dropdown-menu">
-                    <li><a href="#" ng-click="rmc.activateNewSliceMode()">New slice</a></li>
-                    <li><a href="#" ng-click="rmc.activateNewCoreMode()"
-                           ng-show="rmc.getSlicesCount() > 0">New core</a></li>
-                    <li><a href="#" ng-click="rmc.activateNewFocusRegionMode()"
-                           ng-show="rmc.getCoresCount() > 0">New focus region</a></li>
-                </ul>
-            </div>
+            <button class="btn btn-info" style="margin-left: 15px;"
+                    ng-click="rmc.activateNewSliceMode()"
+                    ng-disabled="rmc.newItemCreationModeActive() || rmc.editItemModeActive()">
+                    <i class="icon-plus"></i> New slice
+            </button>
+            <button class="btn btn-info"
+                    ng-click="rmc.activateNewCoreMode()"
+                    ng-disabled="rmc.newItemCreationModeActive() || rmc.editItemModeActive() || rmc.getSlicesCount() == 0">
+                    <i class="icon-plus"></i> New core
+            </button>
+            <button class="btn btn-info" style="margin-right: 15px;"
+                    ng-click="rmc.activateNewFocusRegionMode()"
+                    ng-disabled="rmc.newItemCreationModeActive() || rmc.editItemModeActive() || rmc.getCoresCount() == 0">
+                    <i class="icon-plus"></i> New focus region
+            </button>
             <button class="btn btn-success" ng-click="rmc.closeROIsAnnotationStep()"
                     ng-disabled="rmc.getSlicesCount() == 0 || rmc.newItemCreationModeActive() || rmc.editItemModeActive()">
                 <i class="icon-check_circle"></i> Confirm ROIs

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -143,7 +143,7 @@
             </div>
         </div>
         <div class="col-sm-6 col-md-8">
-            <div class="well row prm-hm-controls">
+            <div id="heatmap_controls" class="well row prm-hm-controls">
                 <div class="col-sm-4 text-center">
                     <div class="col-sm-4 prm-label-elem text-right">
                         <h4 for="hm-palette">PALETTE</h4>

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -66,16 +66,16 @@
                     </div>
                 </div>
                 <div class="form-group row">
-                    <div class="col-sm-6 prm-label-elem">
+                    <div class="col-sm-7 prm-label-elem">
                         <h4 class="text-left" style="margin: 5px;">Cluster radius</h4>
                     </div>
-                    <div class="col-sm-6 prm-form-elem">
+                    <div class="col-sm-5 prm-form-elem">
                         <select class="form-control prm-text-input" id="cluster_size_ctrl"
                                 ng-model="rmc.navmap_cluster_size"
                                 ng-change="rmc.updateNavmapClusterSize()">
                             <option value="2" selected="selected">Small</option>
                             <option value="4">Medium</option>
-                            <option value="8">Large</option>
+                            <option value="6">Large</option>
                         </select>
                     </div>
                 </div>
@@ -143,7 +143,7 @@
             </div>
         </div>
         <div class="col-sm-6 col-md-8">
-            <div class="well row" style="background-color:white;">
+            <div class="well row prm-hm-controls">
                 <div class="col-sm-4 text-center">
                     <div class="col-sm-4 prm-label-elem text-right">
                         <h4 for="hm-palette">PALETTE</h4>

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -65,7 +65,7 @@
                         <label for="show_map" class="label-primary"></label>
                     </div>
                 </div>
-                <div class="form-group row">
+                <div class="form-group row" id="cluster_size">
                     <div class="col-sm-7 prm-label-elem">
                         <h4 class="text-left" style="margin: 5px;">Cluster radius</h4>
                     </div>
@@ -79,7 +79,41 @@
                         </select>
                     </div>
                 </div>
-                <div class="form-group row">
+                <div class="form-group row" id="slices_filter">
+                    <div class="col-sm-5 prm-label-elem">
+                        <h4 class="text-left" style="margin: 5px;">Slice filter</h4>
+                    </div>
+                    <div class="col-sm-7 prm-form-elem">
+                        <div class="btn-group nav-dropdown" style="width: 100%;">
+                            <button class="btn btn-default dropdown-toggle prm-full-col-btn" data-toggle="dropdown"
+                                    ng-disabled="rmc.disableNavmapFilter()">
+                                <div class="row">
+                                    <div class="col-sm-10 text-left">
+                                        <span id="selected_slice_filter">
+                                            -- No filter --
+                                        </span>
+                                    </div>
+                                    <div class="col-sm-1" style="padding: 0px;">
+                                        <i class="icon-play prm-rotate-90 prm-caret" />
+                                    </div>
+                                </div>
+                            </button>
+                            <ul class="dropdown-menu" style="width: 100%;">
+                                <li>
+                                    <a href="#"
+                                       ng-click="rmc.removeSliceNavmapFilter()">-- No filter --</a>
+                                </li>
+                                <li ng-repeat="(slice_id, slice_label) in rmc.slices_map">
+                                    <a href="#"
+                                       ng-click="rmc.filterNavmapBySlice(slice_label)"
+                                       ng-mouseover="rmc.selectROI('slice', slice_id)"
+                                       ng-mouseleave="rmc.deselectROI('slice', slice_id)">{{ slice_label }}</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group row" id="navmap_items">
                     <div class="col-sm-10" style="padding: 0px 0px 0px 2px;">
                         <div class="btn-group nav-dropdown" style="width: 100%;">
                             <button class="btn btn-default dropdown-toggle prm-full-col-btn" data-toggle="dropdown">

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -88,7 +88,7 @@
                     <div class="col-sm-7 prm-form-elem">
                         <div class="btn-group nav-dropdown" style="width: 100%;">
                             <button class="btn btn-default dropdown-toggle prm-full-col-btn" data-toggle="dropdown"
-                                    ng-disabled="rmc.disableNavmapFilter()">
+                                    ng-disabled="rmc.getSlicesCount() == 0">
                                 <div class="row">
                                     <div class="col-sm-10 text-left">
                                         <span id="selected_slice_filter">

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -188,9 +188,9 @@
                         <select class="form-control prm-text-input" id="palette_ctrl"
                                 ng-model="rmc.overlay_palette"
                                 ng-change="rmc.updateOverlayPalette()">
-                            <option value="Greens_9" selected="selected">Green (10 values)</option>
-                            <option value="Blues_9">Blue (10 values)</option>
                             <option value="Reds_9">Red (10 values)</option>
+                            <option value="Greens_9">Green (10 values)</option>
+                            <option value="Blues_9">Blue (10 values)</option>
                         </select>
                     </div>
                 </div>

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -57,6 +57,14 @@
                 <div class="prm-form-header">
                     <h4 class="text-left">Navigation Map</h4>
                 </div>
+                <div class="form-group row col-sm-12">
+                    <div id="show-map" class="material-switch pull-right">
+                        <span class="label prm-label" style="color:inherit;">Show Map</span>
+                        <input id="show_map" name="show_navmap" type="checkbox"
+                               ng-click="rmc.switchNavmapDisplay()"/>
+                        <label for="show_map" class="label-primary"></label>
+                    </div>
+                </div>
                 <div class="form-group row">
                     <div class="col-sm-10" style="padding: 0px 0px 0px 2px;">
                         <div class="btn-group nav-dropdown" style="width: 100%;">

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -57,12 +57,26 @@
                 <div class="prm-form-header">
                     <h4 class="text-left">Navigation Map</h4>
                 </div>
-                <div class="form-group row col-sm-12">
+                <div class="form-group row col-sm-11">
                     <div id="show-map" class="material-switch pull-right">
                         <span class="label prm-label" style="color:inherit;">Show Map</span>
                         <input id="show_map" name="show_navmap" type="checkbox"
                                ng-click="rmc.switchNavmapDisplay()"/>
                         <label for="show_map" class="label-primary"></label>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-sm-6 prm-label-elem">
+                        <h4 class="text-left" style="margin: 5px;">Cluster radius</h4>
+                    </div>
+                    <div class="col-sm-6 prm-form-elem">
+                        <select class="form-control prm-text-input" id="cluster_size_ctrl"
+                                ng-model="rmc.navmap_cluster_size"
+                                ng-change="rmc.updateNavmapClusterSize()">
+                            <option value="2" selected="selected">Small</option>
+                            <option value="3">Medium</option>
+                            <option value="4">Large</option>
+                        </select>
                     </div>
                 </div>
                 <div class="form-group row">
@@ -166,7 +180,7 @@
                         <select class="form-control prm-text-input" id="threshold_ctrl"
                                 ng-model="rmc.overlay_threshold"
                                 ng-change="rmc.updateOverlayThreshold()">
-                            <option value="0.0" selected="selected">0 %</option>
+                            <option value="0.0">0 %</option>
                             <option value="0.1">10 %</option>
                             <option value="0.2">20 %</option>
                             <option value="0.3">30 %</option>

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -53,6 +53,64 @@
     <div id="pg_body" class="col-sm-12">
         <div class="col-sm-3 col-md-2">
             <viewer-navigation-panel></viewer-navigation-panel>
+            <div id="navigation_map_controls" class="well panel-group">
+                <div class="prm-form-header">
+                    <h4 class="text-left">Navigation Map</h4>
+                </div>
+                <div class="form-group row">
+                    <div class="col-sm-10" style="padding: 0px 0px 0px 2px;">
+                        <div class="btn-group nav-dropdown" style="width: 100%;">
+                            <button class="btn btn-default dropdown-toggle prm-full-col-btn" data-toggle="dropdown">
+                                <div class="row">
+                                    <div class="col-sm-10 text-left">
+                                        <span id="selected_navmap_item">
+                                            -- Select an item --
+                                        </span>
+                                    </div>
+                                    <div class="col-sm-1" style="padding:0px;">
+                                        <i class="icon-play prm-rotate-90 prm-caret" />
+                                    </div>
+                                </div>
+                            </button>
+                            <ul class="dropdown-menu" style="width: 100%;">
+                                <li ng-repeat="label in rmc.navmap_items_label">
+                                    <a href="#"
+                                       ng-click="rmc.jumpToNavmapItem(label)"
+                                       ng-mouseover="rmc.selectNavmapItem(label)"
+                                       ng-mouseleave="rmc.deselectNavmapItem(label)">{{ label }}</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="col-sm-1" style="padding-left:5px;" >
+                        <button class="btn btn-default prm-icon-btn"
+                                ng-click="rmc.jumpToSelectedNavmapItem()"
+                                ng-disabled="rmc.noNavmapItemSelected()"
+                                ng-mouseover="rmc.showSelectedNavmapItem()"
+                                ng-mouseleave="rmc.hideSelectedNavmapItem()"
+                                title="jump to selected cluster"
+                                style="height: 35px;width: 35px;font-size: 20px;">
+                            <i class="icon-placepin"></i>
+                        </button>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-sm-6 text-center" style="padding: 2px;">
+                        <button class="btn btn-default prm-full-col-btn"
+                                ng-disabled="rmc.noNavmapItemSelected() || rmc.isFirstItemSelected()"
+                                ng-click="rmc.jumpToPreviousNavmapItem()">
+                            <i class="icon-arrow_big_left"></i> Previuos
+                        </button>
+                    </div>
+                    <div class="col-sm-6 text-center" style="padding: 2px;">
+                        <button class="btn btn-default prm-full-col-btn"
+                                ng-disabled="rmc.isLastItemSelected()"
+                                ng-click="rmc.jumpToNextNavmapItem()">
+                            Next <i class="icon-arrow_big_right"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
             <div id="navigation" class="well panel-group prm-tree-well">
                 <div class="prm-form-header">
                     <h4 class="text-left">ROIs list</h4>

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -62,8 +62,62 @@
                 </ul>
             </div>
         </div>
-        <div id="viewer_container" class="col-sm-6 col-md-8 prm-viewer_frame well">
-            <roi-annotations-viewer></roi-annotations-viewer>
+        <div class="col-sm-6 col-md-8">
+            <div class="well row" style="background-color:white;">
+                <div class="col-sm-4 text-center">
+                    <div class="col-sm-4 prm-label-elem text-right">
+                        <h4 for="hm-palette">PALETTE</h4>
+                    </div>
+                    <div class="col-sm-8 prm-form-elem">
+                        <select class="form-control prm-text-input" id="palette_ctrl"
+                                ng-model="rmc.overlay_palette"
+                                ng-change="rmc.updateOverlayPalette()">
+                            <option value="Greens_9" selected="selected">Green (10 values)</option>
+                            <option value="Blues_9">Blue (10 values)</option>
+                            <option value="Reds_9">Red (10 values)</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="col-sm-4 text-center">
+                    <div class="col-sm-3 prm-label-elem">
+                        <h4>OPACITY</h4>
+                    </div>
+                    <div class="col-sm-9 prm-form-elem">
+                        <div id="opacity_ctrl" class="input-group prm-row-elem prm-range-selector">
+                            <div class="input-group-addon prm-range-label">0</div>
+                            <input type="range" min="0.0" max="1.0" step="0.01"
+                                ng-model="rmc.overlay_opacity"
+                                ng-change="rmc.updateOverlayOpacity()" />
+                            <div class="input-group-addon prm-range-label">100</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-4 text-center">
+                    <div class="col-sm-6 prm-label-elem text-right">
+                        <h4>THRESHOLD</h4>
+                    </div>
+                    <div class="col-sm-4 prm-form-elem">
+                        <select class="form-control prm-text-input" id="threshold_ctrl"
+                                ng-model="rmc.overlay_threshold"
+                                ng-change="rmc.updateOverlayThreshold()">
+                            <option value="0.0" selected="selected">0 %</option>
+                            <option value="0.1">10 %</option>
+                            <option value="0.2">20 %</option>
+                            <option value="0.3">30 %</option>
+                            <option value="0.4">40 %</option>
+                            <option value="0.5">50 %</option>
+                            <option value="0.6">60 %</option>
+                            <option value="0.7">70 %</option>
+                            <option value="0.8">80 %</option>
+                            <option value="0.9">90 %</option>
+                            <option value="1.0">100 %</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div id="viewer_container" class="row prm-viewer_frame well">
+                <roi-annotations-viewer></roi-annotations-viewer>
+            </div>
         </div>
         <div id="promort_form" class="col-sm-3 col-md-2">
             <div class="well">

--- a/promort/static_src/templates/rois_manager/manager.html
+++ b/promort/static_src/templates/rois_manager/manager.html
@@ -74,8 +74,8 @@
                                 ng-model="rmc.navmap_cluster_size"
                                 ng-change="rmc.updateNavmapClusterSize()">
                             <option value="2" selected="selected">Small</option>
-                            <option value="3">Medium</option>
-                            <option value="4">Large</option>
+                            <option value="4">Medium</option>
+                            <option value="8">Large</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Add tumor prediction mat ROIs annotation step.

Map can be displayed over the virtual slide and a navigation map is automatically generated when a threshold value is selected by the user.

Navigation map can be used to quickly jump over a region with at least one tile with a cancer prediction score greater than the selected threshold.